### PR TITLE
SG update to be able to use the template

### DIFF
--- a/full_studio_dependencies.yml
+++ b/full_studio_dependencies.yml
@@ -50,18 +50,10 @@ Resources:
           - "ec2:DescribeInstances"
           - "ec2:DescribeSubnets"
           - "ec2:DescribeVpcs"
+          - "ec2:CreateTags"
           - "elasticmapreduce:ListInstances"
           - "elasticmapreduce:DescribeCluster"
           - "elasticmapreduce:ListSteps"
-        - Effect: Allow
-          Resource: "arn:aws:ec2:*:*:network-interface/*"
-          Action:
-          - "ec2:CreateTags"
-          Condition:
-            ForAllValues:StringEquals:
-              aws:TagKeys:
-                - aws:elasticmapreduce:editor-id
-                - aws:elasticmapreduce:job-flow-id
         - Effect: Allow
           Resource: "arn:aws:s3:::*"
           Action:


### PR DESCRIPTION
Opening up the security group to avoid an error in the UI when you try to open the EMR Studio. The SG permission should be updated to the latest definition in the AWS documentation; this is just a patch for the people trying to use this template.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution under the terms of your choice.
